### PR TITLE
Saving & Importing tracklogs locally

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -42,85 +42,41 @@
 				<data android:scheme="content" android:mimeType="application/octet-stream" />
 
 			</intent-filter>
+			
 			<intent-filter>
 				<action android:name="android.intent.action.VIEW" />
 				<category android:name="android.intent.category.DEFAULT" />
 				<category android:name="android.intent.category.BROWSABLE" />
-
-				<!--
-					We understand wpt format waypoint files, see
-					http://www.santacruzparagliding.com/NCXC/NCXC_2010_waypoints.wpt
-					for example <data android:scheme="content" android:host="*"
-					android:pathPattern=".*\\.wpt" /> <data android:scheme="content"
-					android:host="*" android:pathPattern=".*\\.WPT" />
-				-->
-
-				<data android:scheme="http" android:host="*"
-					android:pathPattern=".*\\.wpt" />
-				<data android:scheme="https" android:host="*"
-					android:pathPattern=".*\\.wpt" />
-
-				<data android:scheme="file" android:host="*"
-					android:pathPattern=".*\\.wpt" />
-				<data android:scheme="content" android:host="*"
-					android:pathPattern=".*\\.wpt" />
-
-				<data android:scheme="http" android:host="*"
-					android:pathPattern=".*\\.WPT" />
-				<data android:scheme="https" android:host="*"
-					android:pathPattern=".*\\.WPT" />
-
-				<data android:scheme="file" android:host="*"
-					android:pathPattern=".*\\.WPT" />
-				<data android:scheme="content" android:host="*"
-					android:pathPattern=".*\\.WPT" />
-
-				<data android:scheme="http" android:host="*"
-					android:pathPattern=".*\\.dat" />
-				<data android:scheme="https" android:host="*"
-					android:pathPattern=".*\\.dat" />
-
-				<data android:scheme="file" android:host="*"
-					android:pathPattern=".*\\.dat" />
-				<data android:scheme="content" android:host="*"
-					android:pathPattern=".*\\.dat" />
-
-				<data android:scheme="http" android:host="*"
-					android:pathPattern=".*\\.DAT" />
-				<data android:scheme="https" android:host="*"
-					android:pathPattern=".*\\.DAT" />
-
-				<data android:scheme="file" android:host="*"
-					android:pathPattern=".*\\.DAT" />
-				<data android:scheme="content" android:host="*"
-					android:pathPattern=".*\\.DAT" />
-
-				<data android:scheme="http" android:host="*"
-					android:pathPattern=".*\\.cup" />
-				<data android:scheme="https" android:host="*"
-					android:pathPattern=".*\\.cup" />
-
-				<data android:scheme="file" android:host="*"
-					android:pathPattern=".*\\.cup" />
-				<data android:scheme="content" android:host="*"
-					android:pathPattern=".*\\.cup" />
-
-				<data android:scheme="http" android:host="*"
-					android:pathPattern=".*\\.CUP" />
-				<data android:scheme="https" android:host="*"
-					android:pathPattern=".*\\.CUP" />
-
-				<data android:scheme="file" android:host="*"
-					android:pathPattern=".*\\.CUP" />
-				<data android:scheme="content" android:host="*"
-					android:pathPattern=".*\\.CUP" />
-
-				<!--
-					<data android:scheme="http" android:host="*"
-					android:pathPattern=".*" android:mimeType="application/download" />
-					<data android:scheme="http" />
-				-->
-
+				
+				<data android:scheme="http" />
+				<data android:scheme="https" />
+				<data android:host="*" />
+				<data android:pathPattern=".*\\.WPT" />
+				<data android:pathPattern=".*\\.wpt" />
+				<data android:pathPattern=".*\\.DAT" />
+				<data android:pathPattern=".*\\.dat" />
+				<data android:pathPattern=".*\\.CUP" />
+				<data android:pathPattern=".*\\.cup" />
+			</intent-filter>
+			<!-- 
+				We're using separate intent-filters for download (http/s) and local files (file/content) as they require
+				different settings for mimeType to each other.
+			  -->
+			<intent-filter>
+				<action android:name="android.intent.action.VIEW" />
+				<category android:name="android.intent.category.DEFAULT" />
+				<category android:name="android.intent.category.BROWSABLE" />
+				
+				<data android:scheme="file" />
+				<data android:scheme="content" /> 
+				<data android:host="*" />
+				<data android:pathPattern=".*\\.WPT" />
+				<data android:pathPattern=".*\\.wpt" />
+				<data android:pathPattern=".*\\.DAT" />
+				<data android:pathPattern=".*\\.dat" />
+				<data android:pathPattern=".*\\.CUP" />
+				<data android:pathPattern=".*\\.cup" />
+				<data android:mimeType="*/*" />
 			</intent-filter>
 		</activity>
 
@@ -138,23 +94,28 @@
 				<action android:name="android.intent.action.VIEW" />
 				<category android:name="android.intent.category.DEFAULT" />
 				<category android:name="android.intent.category.BROWSABLE" />
-				<data android:scheme="http" android:host="*"
-					android:pathPattern=".*\\.igc" />
-				<data android:scheme="https" android:host="*"
-					android:pathPattern=".*\\.igc" />
-				<data android:scheme="content" android:host="*"
-					android:pathPattern=".*\\.igc" />
-				<data android:scheme="file" android:host="*"
-					android:pathPattern=".*\\.igc" />
-
-				<data android:scheme="http" android:host="*"
-					android:pathPattern=".*\\.IGC" />
-				<data android:scheme="https" android:host="*"
-					android:pathPattern=".*\\.IGC" />
-				<data android:scheme="content" android:host="*"
-					android:pathPattern=".*\\.IGC" />
-				<data android:scheme="file" android:host="*"
-					android:pathPattern=".*\\.IGC" />
+				
+				<data android:scheme="http" />
+				<data android:scheme="https" />
+				<data android:host="*" />
+				<data android:pathPattern=".*\\.IGC" />
+				<data android:pathPattern=".*\\.igc" />
+			</intent-filter>
+			<!-- 
+				We're using separate intent-filters for download (http/s) and local files (file/content) as they require
+				different settings for mimeType to each other.
+			  -->
+			<intent-filter>
+				<action android:name="android.intent.action.VIEW" />
+				<category android:name="android.intent.category.DEFAULT" />
+				<category android:name="android.intent.category.BROWSABLE" />
+				
+				<data android:scheme="file" />
+				<data android:scheme="content" /> 
+				<data android:host="*" />
+				<data android:pathPattern=".*\\.IGC" />
+				<data android:pathPattern=".*\\.igc" />
+				<data android:mimeType="*/*" />
 			</intent-filter>
 		</activity>
 		<!--   <uses-library android:name="com.google.android.maps" /> -->

--- a/assets/no_waypoints.html
+++ b/assets/no_waypoints.html
@@ -6,14 +6,15 @@
 <link href="main.css" rel="stylesheet" type="text/css" media="screen"> 
 </head>
 <body>
-It seems you haven't created any waypoints yet.  There are two ways to add waypoints:
+It seems you haven't created any waypoints yet.  There are three ways to add waypoints:
 
 <ul><li>If you visit a waypoint file on the web, when you open the file, just choose "Open with Gaggle".  
 For an example, try downloading from the <a href="http://www.santacruzparagliding.com/NCXC/NCXC_2010_waypoints.wpt">Norcal XC league</a> or 
 many waypoint files can be found in the <a href="http://soaringweb.org/TP">Worldwide Soaring Turnpoint Exchange</a>.    
-<br><br>The CompeGPS and OziExplorer waypoint formats are known to work.  If you'd like to see another format supported, please post a request in the 
-<a href="manual/support.html">user forum</a>.</li>
-<br></br>
+<br /><br />The CompeGPS, OziExplorer, Cambridge .dat & SeeYou .cup waypoint formats are known to work.  If you'd like to see another format supported, please post a request in the 
+<a href="manual/support.html">user forum</a>. <br />After importing a waypoint file, the file will be saved on your device. Look for the \Gaggle\Waypoints folder. <br /><br /></li>
+<li>Open a file browser app on your android device. Browse to, then select a waypoint file. Gaggle will then import that file.</li>
+<br /><br />
 <li>You can add waypoints manually.  Just press Menu button and choose "Add waypoint."</li>
 </ul>
 </body></html>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -159,6 +159,8 @@ Still waiting for GPS fix</string>
     <string name="uploading">Uploading</string>
     <string name="flight_">flight_</string>
     <string name="tracklogs">Tracklogs</string>
+    <string name="file_folder">Gaggle</string>
+    <string name="waypoints">Waypoints</string>
     <string name="sd_card_not_found">SD card not found</string>
     <string name="file_write_failed">File write failed</string>
     <string name="please_set_your_leonardo_account_information">Please set your Leonardo account information</string>

--- a/src/com/geeksville/gaggle/ListFlightsActivity.java
+++ b/src/com/geeksville/gaggle/ListFlightsActivity.java
@@ -413,10 +413,15 @@ public class ListFlightsActivity extends DBListActivity {
 		if (!sdcard.exists())
 			throw new IOException(getString(R.string.sd_card_not_found));
 
-		File tracklog = new File(sdcard, getString(R.string.tracklogs));
+		String path = getString(R.string.file_folder); 
+		File tracklog = new File(sdcard, path);
 		if (!tracklog.exists())
 			tracklog.mkdir();
-
+		path += '/' + getString(R.string.tracklogs);
+		tracklog = new File(sdcard, path);
+		if (!tracklog.exists())
+			tracklog.mkdir();
+		
 		String basename = getString(R.string.flight_) + flightid + "." + filetype; // FIXME,
 		// use
 		// a

--- a/src/com/geeksville/location/WPTImporter.java
+++ b/src/com/geeksville/location/WPTImporter.java
@@ -23,15 +23,7 @@ package com.geeksville.location;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.List;
-import java.util.SortedMap;
-import java.util.StringTokenizer;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import com.geeksville.location.parse.*;
-
-import android.util.Log;
 
 /**
  * Import waypoints (.wpt files into our DB)
@@ -75,7 +67,7 @@ public class WPTImporter {
 	public WPTImporter(WaypointDB db) {
 		this.db = db;
 	}
-
+	public String fileContents;
 	/**
 	 * 
 	 * @param s
@@ -95,22 +87,23 @@ public class WPTImporter {
 				sb.append(line);
 			}
 		}
+		fileContents = sb.toString();
 		
 		Parse parser;
 				
-		parser = new CambridgeDat(sb.toString(), db);
+		parser = new CambridgeDat(fileContents, db);
 		if (parser.Find() == 0)
 		{
-			parser = new CompeGPS(sb.toString(),db);
+			parser = new CompeGPS(fileContents,db);
 			if (parser.Find() == 0)
 			{ 
-				parser = new OziExplorer(sb.toString(),db);
+				parser = new OziExplorer(fileContents,db);
 				if (parser.Find() == 0)
 				{ 
-					parser = new SeeYouCUP(sb.toString(),db);
+					parser = new SeeYouCUP(fileContents,db);
 					if (parser.Find() == 0)
 					{
-						parser = new Jug(sb.toString(),db);
+						parser = new Jug(fileContents,db);
 						parser.Find();
 					}
 				}


### PR DESCRIPTION
- Tidied up intent-filters to enable .dat, .wpt, .cup & .igc files to open from web browser links, as well as from a file browser - so that locally stored tracklogs will be able to be imported.
- Added file_folder called "Gaggle" as the root folder for gaggle's tracklogs & imported waypoints files to be kept under.
- Moved /tracklogs folder under /Gaggle folder
- Saving imported waypoints files in /Gaggle/Waypoints
  refs #29

Signed-off-by: Dawson Brown dawson@nhgc.asn.au
