### PR TITLE
color coded lift/sink in the map view

### DIFF
--- a/src/com/geeksville/maps/TracklogOverlay.java
+++ b/src/com/geeksville/maps/TracklogOverlay.java
@@ -3,6 +3,8 @@
  */
 package com.geeksville.maps;
 
+import java.util.ArrayList;
+
 import org.andnav.osm.util.GeoPoint;
 import org.andnav.osm.views.OpenStreetMapView;
 import org.andnav.osm.views.OpenStreetMapView.OpenStreetMapViewProjection;
@@ -14,6 +16,9 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Paint.Style;
 import android.graphics.Point;
+import android.graphics.Rect;
+import android.graphics.drawable.PaintDrawable;
+import android.util.Log;
 
 import com.geeksville.location.LocationList;
 
@@ -28,154 +33,146 @@ public class TracklogOverlay extends OpenStreetMapViewPathOverlay {
 	LocationList tracklog;
 
 	/**
-	 * Max up/down millimeter/sec we've seen so far
+	 * Max up/down millimeter/sec -- FIXME: set according to vario limits
 	 */
-	int maxMMeterSec, minMMeterSec;
+	float maxMMeterSec = 5.0f, 
+	      minMMeterSec = -5.0f;
 
 	/**
-	 * The color we use for drawing our tracklog
+	 * The colors we use for drawing our tracklog
 	 */
-	Paint trackPaint = new Paint();
+	Paint[] trackPaints = new Paint[256];
+  private ArrayList<Point> mPoints;
+	private ArrayList<Paint> mColors;
 
-	/**
-	 * 256 colors, 0th position is 'most down' and 255th position is 'most up'
-	 */
-	int[] hsvMap = new int[256];
-
+  static final int POINT_BUFFER_SIZE = 4; //should be a multiple of 4
+  private float[] mPointBuffer = new float[POINT_BUFFER_SIZE];
+  private final Point mTempPoint1 = new Point();
+  private final Point mTempPoint2 = new Point();
+  
 	public TracklogOverlay(Context ctx, LocationList locs) {
 		super(Color.RED, ctx);
 
 		tracklog = locs;
 
-		trackPaint.setStyle(Style.STROKE);
-		trackPaint.setStrokeWidth(2);
-
-		calcHSVMap();
+		precalcTrackPaints();
 	}
 
-	private void calcHSVMap() {
-		float[] hsv = { 1.0f, 1.0f, 1.0f };
-
-		for (int i = 0; i < hsvMap.length; i++) {
-			hsv[0] = (float) i * 360 / hsvMap.length;
-
-			hsvMap[i] = Color.HSVToColor(hsv);
-		}
+	private void precalcTrackPaints() {
+	  for (int i=0;i<256;i++) {
+	    Paint trackPaint = new Paint();
+	    trackPaint.setColor(Color.rgb(255-Math.abs(127-i)*2, i, 255-i));  // blue -> red -> green
+      trackPaint.setStyle(Style.STROKE);
+      trackPaint.setStrokeWidth(2);
+      trackPaints[i]=trackPaint;
+	  }
 	}
 
-	/**
-	 * Draw a red line for our tracklog
-	 * 
-	 * @see Overlay#draw(android.graphics.Canvas, boolean)
-	 */
-	public void fixmeBustedOnOSM(Canvas canvas, OpenStreetMapView mapView) {
+  @Override
+  public void clearPath()
+  {
+      this.mPoints = new ArrayList<Point>();
+      this.mColors = new ArrayList<Paint>();
+  }
 
-		OpenStreetMapViewProjection proj = mapView.getProjection();
+  /**
+   * This method draws the line.
+   * Note - highly optimized to handle long paths, proceed with care. Should be fine up to 10K points.
+   */
+  @Override
+  protected void onDraw(Canvas canvas, OpenStreetMapView mapView) 
+  {
+          if (this.tracklog.numPoints() < 2)
+          {
+                  //nothing to paint
+                  return;
+          }
 
-		Point p = new Point();
-		int prevZ = 0, prevTime = 0;
-		float prevX = 0, prevY = 0;
-		boolean hasPrev = false;
+          final OpenStreetMapViewProjection pj = mapView.getProjection();
+          
+          int size = this.tracklog.numPoints();
+          if (size > mPoints.size()) {
+            for (int i=mPoints.size(); i<size; i++) {
+              GeoPoint gpt = this.tracklog.getGeoPoint(i);
+              Point pt = new Point(gpt.getLatitudeE6(), gpt.getLongitudeE6());
+              pj.toMapPixelsProjected(pt.x, pt.y, pt); //convert to map projection
+              mPoints.add(pt);
+              if (i>0) {
+                float rise = (tracklog.getAltitudeMM(i) - tracklog.getAltitudeMM(i-1)) / (tracklog.getTimeMsec(i) - tracklog.getTimeMsec(i-1)); // mm/ms = m/s
+                rise       = Math.min(Math.max(rise,minMMeterSec),maxMMeterSec); // bound to limits
+                float level  = (rise - minMMeterSec) / (maxMMeterSec - minMMeterSec) * 255.f;
+                mColors.add(trackPaints[(int)level]);
+              } else
+                mColors.add(trackPaints[127]); 
+            }
+          }
+                            
+          Point screenPoint0 = null; //points on screen
+          Point screenPoint1 = null;
+          Point projectedPoint0; //points from the points list
+          Point projectedPoint1;
+          
+          float [] buffer = this.mPointBuffer;
+          int bufferCount = 0;            
+          Rect clipBounds = pj.fromPixelsToProjected(canvas.getClipBounds()); // clipping rectangle in the intermediate projection, to avoid performing projection.
+          Rect lineBounds = new Rect(); // bounding rectangle for the current line segment.
+          
+          projectedPoint0 = this.mPoints.get(size - 1);           
+          lineBounds.set(projectedPoint0.x, projectedPoint0.y, projectedPoint0.x, projectedPoint0.y);
 
-		int[] times = tracklog.timeMsec.toUnsafeArray();
-		int[] alts = tracklog.altitudeMM.toUnsafeArray();
+          for(int i = size - 2; i >= 0; i--)
+          {
+                  //compute next points
+                  projectedPoint1 = this.mPoints.get(i);
+                  lineBounds.union(projectedPoint1.x, projectedPoint1.y);
+                  
+                  if (!Rect.intersects(clipBounds, lineBounds))
+                  {
+                          //skip this line, move to next point
+                          projectedPoint0 = projectedPoint1;                              
+                          screenPoint0 = null;
+                          continue;
+                  }
+                  
+                  // the starting point may be not calculated, because previous segment was out of clip bounds                    
+                  if (screenPoint0 == null)
+                  {
+                          screenPoint0 = pj.toMapPixelsTranslated(projectedPoint0, this.mTempPoint1);
+                  }
+                                          
+                  screenPoint1 = pj.toMapPixelsTranslated(projectedPoint1, this.mTempPoint2);
+                  
+                  //skip this point, too close to previous point
+                  if (Math.abs(screenPoint1.x - screenPoint0.x) + Math.abs(screenPoint1.y - screenPoint0.y) <= 1)
+                  {
+                          continue;
+                  }
+                  
+                  //add new line to buffer                        
+                  buffer[bufferCount] = screenPoint0.x;
+                  buffer[bufferCount + 1] = screenPoint0.y;
+                  buffer[bufferCount + 2] = screenPoint1.x;
+                  buffer[bufferCount + 3] = screenPoint1.y;
+                  bufferCount += 4;
+                  
+                  if (bufferCount == POINT_BUFFER_SIZE)
+                  {
+                          canvas.drawLines(buffer, this.mColors.get(i));
+                          bufferCount = 0;
+                  }                               
+                  
+                  //update starting point to next position 
+                  projectedPoint0 = projectedPoint1;                      
+                  screenPoint0.x = screenPoint1.x;
+                  screenPoint0.y = screenPoint1.y;                        
+                  lineBounds.set(projectedPoint0.x, projectedPoint0.y, projectedPoint0.x, projectedPoint0.y);                     
+          }
 
-		// Provide rational initial condition
-		if (tracklog.numPoints() > 0) {
-			prevZ = alts[0];
-			prevTime = times[0];
-		}
-
-		int hue = hsvMap.length / 2; // Default to something middling
-		for (int i = 0; i < tracklog.numPoints(); i++) {
-			GeoPoint gp = tracklog.getGeoPoint(i);
-			int curTime = times[i];
-			// for time
-			// FIXME - busted on OSM
-			// proj.toPixels(gp, p);
-
-			if (hasPrev) {
-				int deltaMsec = curTime - prevTime;
-
-				// Integrate over the last X seconds of time
-				int integrateMsec = 10 * 1000;
-
-				if (deltaMsec > integrateMsec) {
-					int curZ = alts[i];
-					int deltaMM = curZ - prevZ;
-					int mmPerSecUp = (deltaMM * 1000) / deltaMsec;
-
-					if (mmPerSecUp > maxMMeterSec)
-						maxMMeterSec = mmPerSecUp;
-
-					if (mmPerSecUp < minMMeterSec)
-						minMMeterSec = mmPerSecUp;
-
-					// linear interpolate between min and max vert speed, 1.0==
-					// max
-					hue = (hsvMap.length - 1) * (mmPerSecUp - minMMeterSec)
-							/ (maxMMeterSec - minMMeterSec);
-
-					// Scale hue so max up is yellow, and max down is blue
-					if (hue >= hsvMap.length)
-						hue = hsvMap.length - 1;
-					else if (hue < 0)
-						hue = 0;
-
-					prevTime = curTime;
-					prevZ = curZ;
-					// FIXME, we should do some sort of moving boxcar average
-					// instead
-				}
-
-				// trackPaint.setARGB(255, 255, 0, 0);
-				int color = hsvMap[hue];
-
-				trackPaint.setColor(color);
-
-				// FIXME - for live flights we should only plot a detailed
-				// tracklog for the last
-				// 20 minutes. Prior to that we
-				// can skip points
-
-				// FIXME, the array based versions are probably faster
-				canvas.drawLine(prevX, prevY, p.x, p.y, trackPaint);
-			}
-
-			prevX = p.x;
-			prevY = p.y;
-			hasPrev = true;
-		}
-	}
-
-	/**
-	 * Until I can customize the OSM code, convert to their format
-	 */
-	private void convertToOSM() {
-		int mycount = tracklog.numPoints();
-		int osmCount = getNumberOfPoints();
-
-		if (mycount < osmCount) {
-			clearPath();
-			osmCount = 0;
-		}
-
-		for (int i = osmCount; i < mycount; i++)
-			addPoint(tracklog.getGeoPoint(i));
-	}
-
-	/**
-	 * Convert our points into OSM format then call their drawer
-	 * 
-	 * @see org.andnav.osm.views.overlay.OpenStreetMapViewPathOverlay#onDraw(android.graphics.Canvas,
-	 *      org.andnav.osm.views.OpenStreetMapView)
-	 */
-	@Override
-	protected void onDraw(Canvas canvas, OpenStreetMapView mapView) {
-
-		convertToOSM();
-
-		super.onDraw(canvas, mapView);
-	}
+          if (bufferCount >0 )
+          {
+                  canvas.drawLines(buffer, 0,  bufferCount, this.mPaint);
+          }
+  }
+	
 
 }

--- a/src/com/geeksville/maps/TracklogOverlay.java
+++ b/src/com/geeksville/maps/TracklogOverlay.java
@@ -32,6 +32,8 @@ public class TracklogOverlay extends OpenStreetMapViewPathOverlay {
 
 	LocationList tracklog;
 
+  public final int DETAIL_THRESHOLD = 1000; //the last n points that are drawn with full color detail 
+
 	/**
 	 * Max up/down millimeter/sec -- FIXME: set according to vario limits
 	 */
@@ -45,7 +47,7 @@ public class TracklogOverlay extends OpenStreetMapViewPathOverlay {
   private ArrayList<Point> mPoints;
 	private ArrayList<Paint> mColors;
 
-  static final int POINT_BUFFER_SIZE = 4; //should be a multiple of 4
+  static final int POINT_BUFFER_SIZE = 256; //should be a multiple of 4
   private float[] mPointBuffer = new float[POINT_BUFFER_SIZE];
   private final Point mTempPoint1 = new Point();
   private final Point mTempPoint2 = new Point();
@@ -155,10 +157,13 @@ public class TracklogOverlay extends OpenStreetMapViewPathOverlay {
                   buffer[bufferCount + 3] = screenPoint1.y;
                   bufferCount += 4;
                   
-                  if (bufferCount == POINT_BUFFER_SIZE)
-                  {
-                          canvas.drawLines(buffer, this.mColors.get(i));
-                          bufferCount = 0;
+                  if (i > size - DETAIL_THRESHOLD) {                // if we are in the detailed range 
+                    canvas.drawLines(buffer, this.mColors.get(i));  // paint with accurate colors
+                    bufferCount = 0;
+                  } else 
+                  if (bufferCount == POINT_BUFFER_SIZE) {           // else just paint in red
+                    canvas.drawLines(buffer, this.trackPaints[127]);
+                    bufferCount = 0;
                   }                               
                   
                   //update starting point to next position 


### PR DESCRIPTION
I noticed you had begun to code this, but not integrated with the OSM view. 
I extended the "speed-optimized" OSM onDraw method with buffered per point color information. 

The color information is generated once (currently using basic lift/sink wrt the previous point).

There is a configurable detail cutoff for the last thousand points, before which lines are painted in larger blocks and in neutral red. 
Lift / sink color coding does not take into account max/min lift as before, but is in a static range between -5 to 5 m/s, resulting in a more uniform color scheme for all flights.
These values could be fetched from the vario cutoff configuration or an own config entry.
