### PR TITLE
Display Barometer status, and FlyNet tweaks

### DIFF
--- a/src/com/geeksville/info/InfoBarometer.java
+++ b/src/com/geeksville/info/InfoBarometer.java
@@ -50,9 +50,12 @@ public class InfoBarometer extends InfoField implements Observer {
 	 * 
 	 * @see com.geeksville.info.InfoField#getText()
 	 */
+	private String status;
+	
 	@Override
-	public String getText() {
-		return String.format("%.2f", pressure);
+  public String getText() {
+	  status = (baro == null)?"(none)":baro.getStatus();
+		return String.format("%s %.2f", status, pressure);
 	}
 
 	/**

--- a/src/com/geeksville/location/AndroidBarometerClient.java
+++ b/src/com/geeksville/location/AndroidBarometerClient.java
@@ -59,6 +59,10 @@ public class AndroidBarometerClient extends SensorClient implements
 		this.context = context;
 	}
 
+	public String getStatus() {
+    return "int.";
+  }
+
 	/*
 	 * (non-Javadoc)
 	 * 

--- a/src/com/geeksville/location/BarometerClient.java
+++ b/src/com/geeksville/location/BarometerClient.java
@@ -22,6 +22,7 @@ package com.geeksville.location;
 
 import android.content.Context;
 import android.util.Log;
+import android.widget.Toast;
 
 /// FIXME - add a basic vario http://www.paraglidingforum.com/viewtopic.php?p=48465
 public class BarometerClient {
@@ -47,6 +48,11 @@ public class BarometerClient {
       instance = new CNESBarometerClient(context);
     if (instance == null && AndroidBarometerClient.isAvailable())
       instance = new AndroidBarometerClient(context);
+    
+    /*if (instance != null)
+      Toast.makeText(context, "Discovered: "+instance.getStatus(), 1000);
+    else
+      Toast.makeText(context, "No barometer available.", 1000);*/
 
     return instance;
   }

--- a/src/com/geeksville/location/BarometerClient.java
+++ b/src/com/geeksville/location/BarometerClient.java
@@ -49,11 +49,6 @@ public class BarometerClient {
     if (instance == null && AndroidBarometerClient.isAvailable())
       instance = new AndroidBarometerClient(context);
     
-    /*if (instance != null)
-      Toast.makeText(context, "Discovered: "+instance.getStatus(), 1000);
-    else
-      Toast.makeText(context, "No barometer available.", 1000);*/
-
     return instance;
   }
 

--- a/src/com/geeksville/location/CNESBarometerClient.java
+++ b/src/com/geeksville/location/CNESBarometerClient.java
@@ -61,10 +61,7 @@ public class CNESBarometerClient extends Observable implements
   // / true if we've been set based on the GPS
   private boolean isCalibrated = false;
 
-  private Context context;
-
   public CNESBarometerClient(Context context) {
-    this.context = context;
     this.device = findDevice();
 
     // We do all the real work in a background thread, so we don't stall and can
@@ -173,9 +170,6 @@ public class CNESBarometerClient extends Observable implements
   public void run() {
     BluetoothSocket socket = null;
     try {
-      Toast.makeText(context, "Using Bluetooth Vario", Toast.LENGTH_LONG)
-          .show();
-
       // FIXME, add outer loop to reconnect if bluetooth device is rebooted
       socket = device.createRfcommSocketToServiceRecord(uuid);
 

--- a/src/com/geeksville/location/CNESBarometerClient.java
+++ b/src/com/geeksville/location/CNESBarometerClient.java
@@ -83,6 +83,10 @@ public class CNESBarometerClient extends Observable implements
   static boolean isAvailable() {
     return findDevice() != null;
   }
+  
+  public String getStatus() {
+    return "CNES";
+  }
 
   private static BluetoothDevice findDevice() {
     BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();

--- a/src/com/geeksville/location/FlynetBarometerClient.java
+++ b/src/com/geeksville/location/FlynetBarometerClient.java
@@ -60,11 +60,7 @@ public class FlynetBarometerClient extends Observable implements
   private float reference = SensorManager.PRESSURE_STANDARD_ATMOSPHERE;
   LinearRegression regression = new LinearRegression();
 
-  @SuppressWarnings("unused")
-  private Context context;
-  
   public FlynetBarometerClient(Context context) {
-    this.context = context;
     this.device = findDevice();
 
     long xspan = (long) (PreferenceUtil.getFloat(context,

--- a/src/com/geeksville/location/FlynetBarometerClient.java
+++ b/src/com/geeksville/location/FlynetBarometerClient.java
@@ -3,9 +3,9 @@ package com.geeksville.location;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Observable;
+import java.util.Observer;
 import java.util.Set;
 import java.util.UUID;
 
@@ -15,9 +15,7 @@ import android.bluetooth.BluetoothSocket;
 import android.content.Context;
 import android.hardware.SensorManager;
 import android.location.Location;
-import android.os.Looper;
 import android.util.Log;
-import android.widget.Toast;
 
 import com.geeksville.android.PreferenceUtil;
 import com.geeksville.util.LinearRegression;
@@ -45,10 +43,12 @@ public class FlynetBarometerClient extends Observable implements
   private final String CMD_DEVICENAME  = "_USR";
 
   /** A unique ID for our app */
+  @SuppressWarnings("unused")
   private UUID uuid = UUID.fromString("b00d0c47-899b-4484-810a-5b27a514e906");
 
   private BluetoothDevice device;
   private Thread thread;
+  private String status = "FlyNet";
 
   private float batPercentage, pressure, altitude;
   private boolean isCharging = false;
@@ -60,32 +60,32 @@ public class FlynetBarometerClient extends Observable implements
   private float reference = SensorManager.PRESSURE_STANDARD_ATMOSPHERE;
   LinearRegression regression = new LinearRegression();
 
+  @SuppressWarnings("unused")
   private Context context;
-
+  
   public FlynetBarometerClient(Context context) {
     this.context = context;
     this.device = findDevice();
 
-    // We do all the real work in a background thread, so we don't stall and can
-    // handle reboots of the bluetooth device
-
-    // FIXME this burns too much power, we should instead only create our reader
-    // thread in addObserver, then
-    // shut it down gracefully when the number of observers drops to zero. This
-    // will have the nice effect of only talking
-    // to the bluetooth baro when we actually need its data.
-    thread = new Thread(this, "FlyNet");
-    thread.setDaemon(true);
-    thread.start();
-    
     long xspan = (long) (PreferenceUtil.getFloat(context,
         "integration_period2", 0.7f) * 1000);
     regression.setXspan(xspan);
   }
+  
+  public void addObserver(Observer observer) {
+    super.addObserver(observer);
+
+    // We do all the real work in a background thread, so we don't stall and can
+    // handle reboots of the bluetooth device
+    if ((thread==null)||(thread.isAlive()==false)) {
+      thread = new Thread(this, "FlyNet");
+      thread.setDaemon(true);
+      thread.start();
+    }
+  }
 
   static boolean isAvailable() {
     BluetoothDevice found = findDevice();
-    Log.d(TAG, "Found devices: " + found);
     return found != null;
   }
 
@@ -98,7 +98,6 @@ public class FlynetBarometerClient extends Observable implements
         if ((device.getBluetoothClass().getDeviceClass() == myClass)) {
           Log.d(TAG,
               "Connected to " + device.getName() + "@" + device.getAddress() + " which has device ID " + device.getBluetoothClass().getDeviceClass());
-          //if (device.getName().startsWith(myName))
           return device;
         }
       }
@@ -137,6 +136,12 @@ public class FlynetBarometerClient extends Observable implements
   }
   public boolean isCharging() {
     return isCharging;
+  }
+  public String getStatus() {
+    return status;
+  }
+  public void setStatus(String s) {
+    status = s;
   }
 
   @Override
@@ -185,12 +190,9 @@ public class FlynetBarometerClient extends Observable implements
   @Override
   public void run() {
     BluetoothSocket socket = null;
-    Log.d(TAG, "Using FlyNet Vario");
-    //Toast.makeText(context, "Using FlyNet Vario", Toast.LENGTH_LONG) /* FIXME - can't create handler inside thread */
-    //    .show();
       
-    while (true) {
-      Log.d(TAG, "Reconnecting to FlyNet Vario");
+    do {
+      setStatus("? FlyNet");
       try {
         //socket = device.createRfcommSocketToServiceRecord(uuid); /* NOTE - does not work in Android 2.1/2.2 */
         BluetoothDevice hxm = BluetoothAdapter.getDefaultAdapter().getRemoteDevice(device.getAddress());
@@ -202,25 +204,27 @@ public class FlynetBarometerClient extends Observable implements
           Log.d(TAG, "Error while creating socket", e);
         }
       
-        
+        if (socket != null) {
         // Connect the device through the socket. This will block
         // until it succeeds or throws an exception
-        socket.connect();
-  
-        // Read messages
-        BufferedReader reader = new BufferedReader(new InputStreamReader(
-            socket.getInputStream()));
-  
-        String line;
-        while ((line = reader.readLine()) != null)
-          handleMessage(line);
-  
-        reader.close();
-  
-        Log.d(TAG, "Disconnected from FlyNet Vario");
-  
-        socket.close();
-        socket = null;
+          socket.connect();
+    
+          // Read messages
+          BufferedReader reader = new BufferedReader(new InputStreamReader(
+              socket.getInputStream()));
+    
+          String line;
+          setStatus("+ FlyNet");
+          while ((line = reader.readLine()) != null)
+            handleMessage(line);
+    
+          reader.close();
+    
+          setStatus("- FlyNet");
+    
+          socket.close();
+          socket = null;
+        }
       } catch (IOException connectException) {
         // close the socket and get out
         Log.d(TAG, "Error while connecting", connectException);
@@ -231,7 +235,7 @@ public class FlynetBarometerClient extends Observable implements
           // Ignore errors on close
         }
       }
-    }
+    } while (this.countObservers() > 0);
   }
 
 }

--- a/src/com/geeksville/location/IBarometerClient.java
+++ b/src/com/geeksville/location/IBarometerClient.java
@@ -27,6 +27,9 @@ public interface IBarometerClient {
   // / Return battery charging status in Percent
   public abstract float getBatteryPercent();
 
+  // / Return a status messsage
+  public abstract String getStatus();
+
 	// / In m/s
 	public abstract float getVerticalSpeed();
 


### PR DESCRIPTION
A simple status message that can display the name and/or status of the barometer used next to the reading. 

For FlyNet, it displays "? FlyNet" if the driver is chosen, but it is searching the device, and "+ FlyNet" if it is connected and has readouts. 
For the other barometers, I set a default status message to "CNET" or "int." respectively.

Also, disables FlyNetBarometer observer thread when no observers are present, to conserve battery.

Flight tested at: http://www.paraglidingforum.com/leonardo/flight/628649 ;) 
