### PR TITLE
Added copright notice to java classes without it.

### DIFF
--- a/src/com/geeksville/gaggle/SummaryListActivity.java
+++ b/src/com/geeksville/gaggle/SummaryListActivity.java
@@ -1,3 +1,23 @@
+/*******************************************************************************
+ * Gaggle is Copyright 2010 by Geeksville Industries LLC, a California limited liability corporation. 
+ * 
+ * Gaggle is distributed under a dual license.  We've chosen this approach because within Gaggle we've used a number
+ * of components that Geeksville Industries LLC might reuse for commercial products.  Gaggle can be distributed under
+ * either of the two licenses listed below.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. 
+ * 
+ * Commercial Distribution License
+ * If you would like to distribute Gaggle (or portions thereof) under a license other than 
+ * the "GNU General Public License, version 2", contact Geeksville Industries.  Geeksville Industries reserves
+ * the right to release Gaggle source code under a commercial license of its choice.
+ * 
+ * GNU Public License, version 2
+ * All other distribution of Gaggle must conform to the terms of the GNU Public License, version 2.  The full
+ * text of this license is included in the Gaggle source, see assets/manual/gpl-2.0.txt.
+ ******************************************************************************/
 package com.geeksville.gaggle;
 
 import java.util.Date;

--- a/src/com/geeksville/gaggle/TopActivity.java
+++ b/src/com/geeksville/gaggle/TopActivity.java
@@ -1,6 +1,23 @@
-/**
+/*******************************************************************************
+ * Gaggle is Copyright 2010 by Geeksville Industries LLC, a California limited liability corporation. 
  * 
- */
+ * Gaggle is distributed under a dual license.  We've chosen this approach because within Gaggle we've used a number
+ * of components that Geeksville Industries LLC might reuse for commercial products.  Gaggle can be distributed under
+ * either of the two licenses listed below.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. 
+ * 
+ * Commercial Distribution License
+ * If you would like to distribute Gaggle (or portions thereof) under a license other than 
+ * the "GNU General Public License, version 2", contact Geeksville Industries.  Geeksville Industries reserves
+ * the right to release Gaggle source code under a commercial license of its choice.
+ * 
+ * GNU Public License, version 2
+ * All other distribution of Gaggle must conform to the terms of the GNU Public License, version 2.  The full
+ * text of this license is included in the Gaggle source, see assets/manual/gpl-2.0.txt.
+ ******************************************************************************/
 package com.geeksville.gaggle;
 
 import java.io.File;
@@ -12,7 +29,6 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;

--- a/src/com/geeksville/info/FlightSummary.java
+++ b/src/com/geeksville/info/FlightSummary.java
@@ -1,3 +1,23 @@
+/*******************************************************************************
+ * Gaggle is Copyright 2010 by Geeksville Industries LLC, a California limited liability corporation. 
+ * 
+ * Gaggle is distributed under a dual license.  We've chosen this approach because within Gaggle we've used a number
+ * of components that Geeksville Industries LLC might reuse for commercial products.  Gaggle can be distributed under
+ * either of the two licenses listed below.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. 
+ * 
+ * Commercial Distribution License
+ * If you would like to distribute Gaggle (or portions thereof) under a license other than 
+ * the "GNU General Public License, version 2", contact Geeksville Industries.  Geeksville Industries reserves
+ * the right to release Gaggle source code under a commercial license of its choice.
+ * 
+ * GNU Public License, version 2
+ * All other distribution of Gaggle must conform to the terms of the GNU Public License, version 2.  The full
+ * text of this license is included in the Gaggle source, see assets/manual/gpl-2.0.txt.
+ ******************************************************************************/
 package com.geeksville.info;
 
 import java.util.Calendar;

--- a/src/com/geeksville/location/CNESBarometerClient.java
+++ b/src/com/geeksville/location/CNESBarometerClient.java
@@ -1,3 +1,23 @@
+/*******************************************************************************
+ * Gaggle is Copyright 2010 by Geeksville Industries LLC, a California limited liability corporation. 
+ * 
+ * Gaggle is distributed under a dual license.  We've chosen this approach because within Gaggle we've used a number
+ * of components that Geeksville Industries LLC might reuse for commercial products.  Gaggle can be distributed under
+ * either of the two licenses listed below.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. 
+ * 
+ * Commercial Distribution License
+ * If you would like to distribute Gaggle (or portions thereof) under a license other than 
+ * the "GNU General Public License, version 2", contact Geeksville Industries.  Geeksville Industries reserves
+ * the right to release Gaggle source code under a commercial license of its choice.
+ * 
+ * GNU Public License, version 2
+ * All other distribution of Gaggle must conform to the terms of the GNU Public License, version 2.  The full
+ * text of this license is included in the Gaggle source, see assets/manual/gpl-2.0.txt.
+ ******************************************************************************/
 package com.geeksville.location;
 
 import java.io.BufferedReader;

--- a/src/com/geeksville/location/FlynetBarometerClient.java
+++ b/src/com/geeksville/location/FlynetBarometerClient.java
@@ -1,3 +1,23 @@
+/*******************************************************************************
+ * Gaggle is Copyright 2010 by Geeksville Industries LLC, a California limited liability corporation. 
+ * 
+ * Gaggle is distributed under a dual license.  We've chosen this approach because within Gaggle we've used a number
+ * of components that Geeksville Industries LLC might reuse for commercial products.  Gaggle can be distributed under
+ * either of the two licenses listed below.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. 
+ * 
+ * Commercial Distribution License
+ * If you would like to distribute Gaggle (or portions thereof) under a license other than 
+ * the "GNU General Public License, version 2", contact Geeksville Industries.  Geeksville Industries reserves
+ * the right to release Gaggle source code under a commercial license of its choice.
+ * 
+ * GNU Public License, version 2
+ * All other distribution of Gaggle must conform to the terms of the GNU Public License, version 2.  The full
+ * text of this license is included in the Gaggle source, see assets/manual/gpl-2.0.txt.
+ ******************************************************************************/
 package com.geeksville.location;
 
 import java.io.BufferedReader;
@@ -85,6 +105,14 @@ public class FlynetBarometerClient extends Observable implements
     return found != null;
   }
 
+  /**
+   * Check device exists and is enabled.
+   * 
+   * - Is there a message elsewhere to say "Have you turned the device on?"
+   * - Is the option shown disabled or does it only appear if the device is found?
+   * 
+   * @return
+   */
   private static BluetoothDevice findDevice() {
     BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
     if (adapter != null && adapter.isEnabled()) {
@@ -102,10 +130,11 @@ public class FlynetBarometerClient extends Observable implements
     return null;
   }
 
+  /**
+   * Set the altitudes in meters above sea level
+   */
   @Override
   public void setAltitude(float meters) {
-    // float p0 = 1013.25f; // Pressure at sea level (hPa)
-    // float p = p0 * (float) Math.pow((1 - meters / 44330), 5.255);
     float p0 = pressure / (float) Math.pow((1 - meters / 44330), 5.255);
 
     reference = p0;

--- a/src/com/geeksville/location/GPSClient.java
+++ b/src/com/geeksville/location/GPSClient.java
@@ -1,6 +1,23 @@
-/**
+/*******************************************************************************
+ * Gaggle is Copyright 2010 by Geeksville Industries LLC, a California limited liability corporation. 
  * 
- */
+ * Gaggle is distributed under a dual license.  We've chosen this approach because within Gaggle we've used a number
+ * of components that Geeksville Industries LLC might reuse for commercial products.  Gaggle can be distributed under
+ * either of the two licenses listed below.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. 
+ * 
+ * Commercial Distribution License
+ * If you would like to distribute Gaggle (or portions thereof) under a license other than 
+ * the "GNU General Public License, version 2", contact Geeksville Industries.  Geeksville Industries reserves
+ * the right to release Gaggle source code under a commercial license of its choice.
+ * 
+ * GNU Public License, version 2
+ * All other distribution of Gaggle must conform to the terms of the GNU Public License, version 2.  The full
+ * text of this license is included in the Gaggle source, see assets/manual/gpl-2.0.txt.
+ ******************************************************************************/
 package com.geeksville.location;
 
 import java.lang.reflect.Method;
@@ -51,6 +68,7 @@ public class GPSClient extends Service implements IGPSClient {
    */
   private static final String TAG = "GPSClient";
 
+  // private inner class
   private MyBinder binder = new MyBinder();
 
   private HandlerThread thread = new HandlerThread("GPSClient");
@@ -567,7 +585,7 @@ public class GPSClient extends Service implements IGPSClient {
           baro.setAltitude((float) location.getAltitude());
         }
 
-        // Before forwarding the location to others, substitude the
+        // Before forwarding the location to others, substitute the
         // (better) baro based altitude
         baro.improveLocation(location);
       }

--- a/src/com/geeksville/location/IBarometerClient.java
+++ b/src/com/geeksville/location/IBarometerClient.java
@@ -1,3 +1,23 @@
+/*******************************************************************************
+ * Gaggle is Copyright 2010 by Geeksville Industries LLC, a California limited liability corporation. 
+ * 
+ * Gaggle is distributed under a dual license.  We've chosen this approach because within Gaggle we've used a number
+ * of components that Geeksville Industries LLC might reuse for commercial products.  Gaggle can be distributed under
+ * either of the two licenses listed below.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. 
+ * 
+ * Commercial Distribution License
+ * If you would like to distribute Gaggle (or portions thereof) under a license other than 
+ * the "GNU General Public License, version 2", contact Geeksville Industries.  Geeksville Industries reserves
+ * the right to release Gaggle source code under a commercial license of its choice.
+ * 
+ * GNU Public License, version 2
+ * All other distribution of Gaggle must conform to the terms of the GNU Public License, version 2.  The full
+ * text of this license is included in the Gaggle source, see assets/manual/gpl-2.0.txt.
+ ******************************************************************************/
 package com.geeksville.location;
 
 import java.util.Observer;
@@ -6,35 +26,58 @@ import android.location.Location;
 
 public interface IBarometerClient {
 
-	/** Cheezy trick to apply preferences changes immediately on view change */
-	public abstract void addObserver(Observer observer);
+  /** Cheezy trick to apply preferences changes immediately on view change */
+  public abstract void addObserver(Observer observer);
 
-	public abstract void deleteObserver(Observer observer);
+  public abstract void deleteObserver(Observer observer);
 
-	// / Given a GPS based altitude, reverse engineer what the correct reference
-	// pressure is
-	public abstract void setAltitude(float meters);
+  /**
+   * Given a GPS based altitude, reverse engineer what the correct reference
+   * pressure is 
+   */
+  public abstract void setAltitude(float meters);
 
-  // / Return altitude in meters
+  /**
+   * Return altitude in meters
+   * 
+   * @return altitude in meters
+   */
   public abstract float getAltitude();
 
-  // / Return pressure in hectoPascal
+  /**
+   * Return pressure in hectoPascal
+   * 
+   * @return pressure in hectopascal (100Pa)
+   */
   public abstract float getPressure();
 
-  // / Return battery charging status in Volt
+  /**
+   * Return battery charging status in Volt
+   * 
+   * @return
+   */
   public abstract float getBattery();
 
-  // / Return battery charging status in Percent
+  /**
+   * Return battery charging status in Percent
+   * 
+   * @return
+   */
   public abstract float getBatteryPercent();
 
-  // / Return a status messsage
-  public abstract String getStatus();
+  /**
+   * Return a status messsage
+   */
+   public abstract String getStatus();
 
-	// / In m/s
-	public abstract float getVerticalSpeed();
+  /**
+   * Return vertical speed in m/s
+   */
+  public abstract float getVerticalSpeed();
 
-	// / If we've been calibrated, override the GPS provided altitude with our
-	// aro based alt
-	public void improveLocation(Location l);
-
+  /**
+   * If we've been calibrated, override the GPS provided altitude with our aro based alt
+   * @param l
+   */
+  public void improveLocation(Location l);
 }

--- a/src/com/geeksville/location/LeonardoLiveWriter.java
+++ b/src/com/geeksville/location/LeonardoLiveWriter.java
@@ -1,6 +1,23 @@
-/**
+/*******************************************************************************
+ * Gaggle is Copyright 2010 by Geeksville Industries LLC, a California limited liability corporation. 
  * 
- */
+ * Gaggle is distributed under a dual license.  We've chosen this approach because within Gaggle we've used a number
+ * of components that Geeksville Industries LLC might reuse for commercial products.  Gaggle can be distributed under
+ * either of the two licenses listed below.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. 
+ * 
+ * Commercial Distribution License
+ * If you would like to distribute Gaggle (or portions thereof) under a license other than 
+ * the "GNU General Public License, version 2", contact Geeksville Industries.  Geeksville Industries reserves
+ * the right to release Gaggle source code under a commercial license of its choice.
+ * 
+ * GNU Public License, version 2
+ * All other distribution of Gaggle must conform to the terms of the GNU Public License, version 2.  The full
+ * text of this license is included in the Gaggle source, see assets/manual/gpl-2.0.txt.
+ ******************************************************************************/
 package com.geeksville.location;
 
 import java.io.BufferedReader;
@@ -25,7 +42,7 @@ import android.util.Log;
 import com.flurry.android.FlurryAgent;
 
 /**
- * Writes tracks to the Paragliding (or other) Lenoardo Live server
+ * Writes tracks to the Paragliding (or other) Leonardo Live server
  * 
  * @author kevinh
  * 

--- a/src/com/geeksville/location/parse/CambridgeDat.java
+++ b/src/com/geeksville/location/parse/CambridgeDat.java
@@ -1,3 +1,23 @@
+/*******************************************************************************
+ * Gaggle is Copyright 2010 by Geeksville Industries LLC, a California limited liability corporation. 
+ * 
+ * Gaggle is distributed under a dual license.  We've chosen this approach because within Gaggle we've used a number
+ * of components that Geeksville Industries LLC might reuse for commercial products.  Gaggle can be distributed under
+ * either of the two licenses listed below.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. 
+ * 
+ * Commercial Distribution License
+ * If you would like to distribute Gaggle (or portions thereof) under a license other than 
+ * the "GNU General Public License, version 2", contact Geeksville Industries.  Geeksville Industries reserves
+ * the right to release Gaggle source code under a commercial license of its choice.
+ * 
+ * GNU Public License, version 2
+ * All other distribution of Gaggle must conform to the terms of the GNU Public License, version 2.  The full
+ * text of this license is included in the Gaggle source, see assets/manual/gpl-2.0.txt.
+ ******************************************************************************/
 package com.geeksville.location.parse;
 
 import android.util.Log;

--- a/src/com/geeksville/location/parse/CompeGPS.java
+++ b/src/com/geeksville/location/parse/CompeGPS.java
@@ -1,3 +1,23 @@
+/*******************************************************************************
+ * Gaggle is Copyright 2010 by Geeksville Industries LLC, a California limited liability corporation. 
+ * 
+ * Gaggle is distributed under a dual license.  We've chosen this approach because within Gaggle we've used a number
+ * of components that Geeksville Industries LLC might reuse for commercial products.  Gaggle can be distributed under
+ * either of the two licenses listed below.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. 
+ * 
+ * Commercial Distribution License
+ * If you would like to distribute Gaggle (or portions thereof) under a license other than 
+ * the "GNU General Public License, version 2", contact Geeksville Industries.  Geeksville Industries reserves
+ * the right to release Gaggle source code under a commercial license of its choice.
+ * 
+ * GNU Public License, version 2
+ * All other distribution of Gaggle must conform to the terms of the GNU Public License, version 2.  The full
+ * text of this license is included in the Gaggle source, see assets/manual/gpl-2.0.txt.
+ ******************************************************************************/
 package com.geeksville.location.parse;
 
 import android.util.Log;

--- a/src/com/geeksville/location/parse/Jug.java
+++ b/src/com/geeksville/location/parse/Jug.java
@@ -1,3 +1,23 @@
+/*******************************************************************************
+ * Gaggle is Copyright 2010 by Geeksville Industries LLC, a California limited liability corporation. 
+ * 
+ * Gaggle is distributed under a dual license.  We've chosen this approach because within Gaggle we've used a number
+ * of components that Geeksville Industries LLC might reuse for commercial products.  Gaggle can be distributed under
+ * either of the two licenses listed below.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. 
+ * 
+ * Commercial Distribution License
+ * If you would like to distribute Gaggle (or portions thereof) under a license other than 
+ * the "GNU General Public License, version 2", contact Geeksville Industries.  Geeksville Industries reserves
+ * the right to release Gaggle source code under a commercial license of its choice.
+ * 
+ * GNU Public License, version 2
+ * All other distribution of Gaggle must conform to the terms of the GNU Public License, version 2.  The full
+ * text of this license is included in the Gaggle source, see assets/manual/gpl-2.0.txt.
+ ******************************************************************************/
 package com.geeksville.location.parse;
 
 import java.util.StringTokenizer;

--- a/src/com/geeksville/location/parse/OziExplorer.java
+++ b/src/com/geeksville/location/parse/OziExplorer.java
@@ -1,3 +1,23 @@
+/*******************************************************************************
+ * Gaggle is Copyright 2010 by Geeksville Industries LLC, a California limited liability corporation. 
+ * 
+ * Gaggle is distributed under a dual license.  We've chosen this approach because within Gaggle we've used a number
+ * of components that Geeksville Industries LLC might reuse for commercial products.  Gaggle can be distributed under
+ * either of the two licenses listed below.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. 
+ * 
+ * Commercial Distribution License
+ * If you would like to distribute Gaggle (or portions thereof) under a license other than 
+ * the "GNU General Public License, version 2", contact Geeksville Industries.  Geeksville Industries reserves
+ * the right to release Gaggle source code under a commercial license of its choice.
+ * 
+ * GNU Public License, version 2
+ * All other distribution of Gaggle must conform to the terms of the GNU Public License, version 2.  The full
+ * text of this license is included in the Gaggle source, see assets/manual/gpl-2.0.txt.
+ ******************************************************************************/
 package com.geeksville.location.parse;
 
 import android.util.Log;

--- a/src/com/geeksville/location/parse/Parse.java
+++ b/src/com/geeksville/location/parse/Parse.java
@@ -1,3 +1,23 @@
+/*******************************************************************************
+ * Gaggle is Copyright 2010 by Geeksville Industries LLC, a California limited liability corporation. 
+ * 
+ * Gaggle is distributed under a dual license.  We've chosen this approach because within Gaggle we've used a number
+ * of components that Geeksville Industries LLC might reuse for commercial products.  Gaggle can be distributed under
+ * either of the two licenses listed below.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. 
+ * 
+ * Commercial Distribution License
+ * If you would like to distribute Gaggle (or portions thereof) under a license other than 
+ * the "GNU General Public License, version 2", contact Geeksville Industries.  Geeksville Industries reserves
+ * the right to release Gaggle source code under a commercial license of its choice.
+ * 
+ * GNU Public License, version 2
+ * All other distribution of Gaggle must conform to the terms of the GNU Public License, version 2.  The full
+ * text of this license is included in the Gaggle source, see assets/manual/gpl-2.0.txt.
+ ******************************************************************************/
 package com.geeksville.location.parse;
 
 import java.util.SortedMap;
@@ -45,7 +65,7 @@ abstract public class Parse {
 				else if (descname.contains("launch") || descname.contains("sp"))
 					type = Waypoint.Type.Launch;
 			}
-			// If the user specified a name, replace any existing itemswith the same name
+			// If the user specified a name, replace any existing items with the same name
 			// FIXME - figure out how to have SQL take care of
 			// merging/replacing existing items
 			ExtendedWaypoint existingWaypoint;

--- a/src/com/geeksville/location/parse/SeeYouCUP.java
+++ b/src/com/geeksville/location/parse/SeeYouCUP.java
@@ -1,3 +1,23 @@
+/*******************************************************************************
+ * Gaggle is Copyright 2010 by Geeksville Industries LLC, a California limited liability corporation. 
+ * 
+ * Gaggle is distributed under a dual license.  We've chosen this approach because within Gaggle we've used a number
+ * of components that Geeksville Industries LLC might reuse for commercial products.  Gaggle can be distributed under
+ * either of the two licenses listed below.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. 
+ * 
+ * Commercial Distribution License
+ * If you would like to distribute Gaggle (or portions thereof) under a license other than 
+ * the "GNU General Public License, version 2", contact Geeksville Industries.  Geeksville Industries reserves
+ * the right to release Gaggle source code under a commercial license of its choice.
+ * 
+ * GNU Public License, version 2
+ * All other distribution of Gaggle must conform to the terms of the GNU Public License, version 2.  The full
+ * text of this license is included in the Gaggle source, see assets/manual/gpl-2.0.txt.
+ ******************************************************************************/
 package com.geeksville.location.parse;
 
 import android.util.Log;

--- a/src/com/geeksville/maps/TracklogOverlay.java
+++ b/src/com/geeksville/maps/TracklogOverlay.java
@@ -1,6 +1,23 @@
-/**
+/*******************************************************************************
+ * Gaggle is Copyright 2010 by Geeksville Industries LLC, a California limited liability corporation. 
  * 
- */
+ * Gaggle is distributed under a dual license.  We've chosen this approach because within Gaggle we've used a number
+ * of components that Geeksville Industries LLC might reuse for commercial products.  Gaggle can be distributed under
+ * either of the two licenses listed below.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. 
+ * 
+ * Commercial Distribution License
+ * If you would like to distribute Gaggle (or portions thereof) under a license other than 
+ * the "GNU General Public License, version 2", contact Geeksville Industries.  Geeksville Industries reserves
+ * the right to release Gaggle source code under a commercial license of its choice.
+ * 
+ * GNU Public License, version 2
+ * All other distribution of Gaggle must conform to the terms of the GNU Public License, version 2.  The full
+ * text of this license is included in the Gaggle source, see assets/manual/gpl-2.0.txt.
+ ******************************************************************************/
 package com.geeksville.maps;
 
 import java.util.ArrayList;
@@ -17,8 +34,6 @@ import android.graphics.Paint;
 import android.graphics.Paint.Style;
 import android.graphics.Point;
 import android.graphics.Rect;
-import android.graphics.drawable.PaintDrawable;
-import android.util.Log;
 
 import com.geeksville.location.LocationList;
 


### PR DESCRIPTION
This one is a bit more tricky - I wasn't sure if all classes that didn't have a copyright notice should have one but just being tidy.

Standardised all current files so that any without a geeksville, google or other copyright notice have one

In addition, a file javadoc change has sneaked in as well as the removal of a couple of redundant imports.

Chanoch
