### PR TITLE
Added Marc's code for adjustment to 1 day date bug in some phones

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -85,7 +85,7 @@ This is a brief summary of the steps needed to localize Gaggle for a new languag
     <string name="units">Units</string>
     <string name="performance_and_model_information">Performance and model information</string>
     <string name="glider_information">Glider information</string>
-    <string name="testing_tools">Testing tools</string>
+    <string name="miscellaneous">Miscellaneous</string>
     <string name="type">Type</string>
     <string name="name">Name</string>
     <string name="description">Description</string>
@@ -283,7 +283,9 @@ please email kevinh@geeksville.com.</string>
 	<string name="donate">Donate</string> 
 	<string name="vario_preferences">Vario Preferences</string>   
 	<string name="advanced">Advanced</string>
-
+    <string name="workaround_1day_offset_bug">Date bug adjustment</string>
+    <string name="compensate_1day_offset_bug">Deduct 1 day from GPS location date.</string>
+	
 	<string name="skylines_tracking">SkyLines live tracking</string>
 	<string name="skylines_tracking_summary">Enable SkyLines live tracking</string>
 	<string name="skylines_server">SkyLines server</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -310,9 +310,10 @@
 		</PreferenceScreen>
 	</PreferenceCategory>
 
-	<PreferenceCategory android:title="@string/testing_tools">
+	<PreferenceCategory android:title="@string/miscellaneous">
 		<CheckBoxPreference android:key="fake_gps_pref"
 			android:title="@string/simulate_gps_data" android:summary="@string/allows_testing_gaggle_at_home" />
 
+		<CheckBoxPreference android:key="workaround_1day_offset_bug" android:summary="@string/compensate_1day_offset_bug" android:title="@string/workaround_1day_offset_bug"/>
 	</PreferenceCategory>
 </PreferenceScreen>

--- a/src/com/geeksville/gaggle/GagglePrefs.java
+++ b/src/com/geeksville/gaggle/GagglePrefs.java
@@ -138,5 +138,7 @@ public class GagglePrefs {
 		return prefs.getString("pilot_name_pref", "").trim();
 	}
 
-
+    public boolean isDateOffsetWorkaroundEnabled(){
+        return prefs.getBoolean("workaround_1day_offset_bug", false);
+    }
 }

--- a/src/com/geeksville/location/GPSClient.java
+++ b/src/com/geeksville/location/GPSClient.java
@@ -33,6 +33,7 @@ import android.widget.Toast;
 
 import com.flurry.android.FlurryAgent;
 import com.geeksville.gaggle.AudioVario;
+import com.geeksville.gaggle.GagglePrefs;
 import com.geeksville.gaggle.R;
 import com.geeksville.gaggle.TopActivity;
 
@@ -102,12 +103,19 @@ public class GPSClient extends Service implements IGPSClient {
 
   private static Map<Context, Republisher> clients = new HashMap<Context, Republisher>();
 
+//  private boolean date_offset_fix;
+
   public GPSClient() {
     try {
       vario = new AudioVario();
     } catch (VerifyError ex) {
       Log.e(TAG, "Not supported on 1.5: " + ex);
     }
+  }
+  
+  public boolean isDateOffsetWorkaroundEnabled() {
+      GagglePrefs prefs = new GagglePrefs(this);
+      return prefs.isDateOffsetWorkaroundEnabled();
   }
 
   /**
@@ -557,6 +565,12 @@ public class GPSClient extends Service implements IGPSClient {
 
     @Override
     public synchronized void onLocationChanged(Location location) {
+    	// http://code.google.com/p/android/issues/detail?id=23937
+    	// Some phones have a bug that cause
+    	// the date from GPS to be offset by 1 day
+    	if (isDateOffsetWorkaroundEnabled()){
+    		location.setTime(location.getTime() - 3600*24*1000);
+    	}
 
       // If we receive a position update, assume the GPS is working
       currentStatus = AVAILABLE;


### PR DESCRIPTION
Hi,

I've extracted Marc's code from his Fragments branch for the fix to the 1 day ahead timestamps on GPS location updates and applied it to the current master.

I've added the option in the Preferences menu to deduct a day from the timestamps
I've renamed the last section of the Preferences menu to Miscellaneous (instead of Testing Tools)

chanoch
